### PR TITLE
Add patch for python-magic

### DIFF
--- a/recipes/libmagic/meta.yaml
+++ b/recipes/libmagic/meta.yaml
@@ -22,11 +22,13 @@ requirements:
     - autoconf
     - m4
     - libtool
-  run:
+    - toolchain
 
 test:
   commands:
     - "file --help &> /dev/null"
+    - "ls $CONDA_PREFIX/lib/libmagic.so"  # [linux]
+    - "ls $CONDA_PREFIX/lib/libmagic.dylib"  # [osx]
 
 about:
   home: http://www.darwinsys.com/file/

--- a/recipes/python-magic/discover-libmagic-dylib.patch
+++ b/recipes/python-magic/discover-libmagic-dylib.patch
@@ -1,0 +1,13 @@
+diff -Naur python-magic-0.4.13/magic.py python-magic-0.4.13-new/magic.py
+--- python-magic-0.4.13/magic.py	2017-03-20 01:23:50.000000000 -0500
++++ python-magic-0.4.13-new/magic.py	2017-03-26 21:04:47.000000000 -0500
+@@ -158,7 +158,8 @@
+     platform_to_lib = {'darwin': ['/opt/local/lib/libmagic.dylib',
+                                   '/usr/local/lib/libmagic.dylib'] +
+                          # Assumes there will only be one version installed
+-                         glob.glob('/usr/local/Cellar/libmagic/*/lib/libmagic.dylib'),
++                         glob.glob('/usr/local/Cellar/libmagic/*/lib/libmagic.dylib') +
++                         glob.glob(os.path.expandvars('$CONDA_PREFIX/lib/libmagic.dylib')),
+                        'win32': windows_dlls,
+                        'cygwin': windows_dlls,
+                        'linux': ['libmagic.so.1'],    # fallback for some Linuxes (e.g. Alpine) where library search does not work

--- a/recipes/python-magic/meta.yaml
+++ b/recipes/python-magic/meta.yaml
@@ -11,6 +11,8 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   {{ hash_type }}: {{ hash_val }}
+  patches:
+    - discover-libmagic-dylib.patch  # [osx]
 
 build:
   number: 0


### PR DESCRIPTION
Hi @mariusvniekerk, just wanted to offer some help with the conda-forge recipes you opened a PR for a week ago. With the following changes I was able to get the build working on my Mac OSX machine.

This PR allows python-magic to look inside the $CONDA_PREFIX directory when searching for libmagic.dylib. It also adds a test to the libmagic recipe to verify that `libmagic.dylib` is getting installed to that location.